### PR TITLE
CMake: add SDL2_IMAGE_INCLUDE_DIR and SDL2_TTF_INCLUDE_DIR to include_directories

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,7 @@
 find_package(SDL2 REQUIRED)
 
 # Include relevat dirs
-include_directories(${SDL2_INCLUDE_DIR} ${KIWI_INCLUDE_DIR})
+include_directories(${SDL2_INCLUDE_DIR} ${SDL2_IMAGE_INCLUDE_DIR} ${SDL2_TTF_INCLUDE_DIR} ${KIWI_INCLUDE_DIR})
 
 # The playground example
 add_subdirectory(playground)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,7 @@ set(LIB_SOURCES
   KW_renderdriver_sdl2.c
 )
 
-include_directories(${SDL2_INCLUDE_DIR})
+include_directories(${SDL2_INCLUDE_DIR} ${SDL2_IMAGE_INCLUDE_DIR} ${SDL2_TTF_INCLUDE_DIR})
 add_library(KiWi SHARED ${LIB_SOURCES} ${API_HEADERS})
 target_link_libraries(KiWi ${SDL2_LIBRARIES} ${SDL2_TTF_LIBRARIES} ${SDL2_IMAGE_LIBRARIES})
 


### PR DESCRIPTION
Needed to add SDL2_IMAGE_INCLUDE_DIR and SDL2_TTF_INCLUDE_DIR to include_directories for situations where the headers are not in the same directory as SDL.
